### PR TITLE
Add Role Based Access for XPR TH & TB cut chart data

### DIFF
--- a/OidcAuthService/OidcAuthService.cs
+++ b/OidcAuthService/OidcAuthService.cs
@@ -46,7 +46,7 @@ namespace Hypertherm.OidcAuth
             var browser = new SystemBrowser(Int32.Parse(_config["RedirectUriPort"]));
             string redirectUri = string.Format($"http://127.0.0.1:{browser.Port}");
 
-            _scopes = "openid profile email api offline_access read create_custom read_custom";
+            _scopes = "openid profile email api offline_access read create_custom read_custom read:truehole read:truebevel";
 
             var oidcOptions = new OidcClientOptions
             {


### PR DESCRIPTION
Added the read:truehole & read:truebevel scopes to the auth request

These scopes will now be requested by default and used to determine if the user has the right role based access to acquire the XPR cut chart data with True Hole and/or True Bevel data.