### PR TITLE
Version 1.4.0

### DIFF
--- a/cc-cli/Program.cs
+++ b/cc-cli/Program.cs
@@ -10,7 +10,7 @@ using Hypertherm.Update;
 using static Hypertherm.Logging.LoggingService;
 using System.Diagnostics;
 
-[assembly:AssemblyVersion("1.3.0.0")]
+[assembly:AssemblyVersion("1.4.0.0")]
 
 namespace Hypertherm.CcCli
 {


### PR DESCRIPTION
XPR TH & TB cut chart data is now accessible using the CLI.