### PR TITLE
Art 6076 inform user when an update is available

### DIFF
--- a/.github/workflows/Action.yml
+++ b/.github/workflows/Action.yml
@@ -97,7 +97,7 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.gitversion.outputs.legacySemVer }}
+        tag_name: v${{ steps.gitversion.outputs.legacySemVer }}
         release_name: Version ${{ steps.gitversion.outputs.legacySemVer }}
     
     - name: Upload a Build Artifact
@@ -118,6 +118,6 @@ jobs:
          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
          asset_path: ./cc-cli.exe
          asset_name: cc-cli.exe
-         asset_content_type: application/zip
+         asset_content_type: application/vnd.microsoft.portable-executable
               
        

--- a/UpdateService/UpdateService.cs
+++ b/UpdateService/UpdateService.cs
@@ -24,7 +24,6 @@ namespace Hypertherm.Update
 
     public class UpdateWithGitHubAPI : IUpdateService
     {
-        private bool _updateIsAvailable = false;
         private string gitHubUrl;
         private IAnalyticsService _analyticsService;
         private ILoggingService _logger;
@@ -51,9 +50,7 @@ namespace Hypertherm.Update
             _analyticsService.GenericTrace($"Checking for available updates.");
             var currentVersion = Version.Parse(Assembly.GetEntryAssembly().GetName().Version.ToString());
 
-            _updateIsAvailable = _latestReleasedVersion > currentVersion;
-
-            return _updateIsAvailable;
+            return _latestReleasedVersion > currentVersion;
         }
 
         public async Task<List<string>> ListReleases()

--- a/UpdateService/UpdateService.cs
+++ b/UpdateService/UpdateService.cs
@@ -47,7 +47,8 @@ namespace Hypertherm.Update
 
         public bool IsUpdateAvailable()
         {
-            _analyticsService.GenericTrace($"Checking for available updates.");
+            _analyticsService.GenericTrace($"Checking for updates.");
+
             var currentVersion = Version.Parse(Assembly.GetEntryAssembly().GetName().Version.ToString());
 
             return _latestReleasedVersion > currentVersion;
@@ -144,7 +145,8 @@ namespace Hypertherm.Update
 
         private async Task GetLatestReleasedVersionInfo()
         {
-            _analyticsService.GenericTrace($"Acquiring the latest release's version info.");
+            _analyticsService.GenericTrace($"Getting the latest release's version information.");
+
 
             SetAcceptHeaderJsonContent();
             SetUserAgentHeader();

--- a/cc-cli/ArgumentHandler.cs
+++ b/cc-cli/ArgumentHandler.cs
@@ -142,12 +142,28 @@ namespace Hypertherm.CcCli
                             _argData.AddToLogString($"   Cannot execute \"{_args[i]}\".");
                         }
                     }
-                    else if (_validParamOptions.ContainsKey(_args[i])
-                        && _args.Count > i + 1)
+                    else if (_validParamOptions.ContainsKey(_args[i]))
                     {
-                        SavePropertyParam(_validParamOptions[_args[i]], _args[i + 1]);
-                        _argData.AddToLogString($"Option: \"{_args[i]}\", Value: \"{_args[i + 1]}\".");
-                        i++;
+                        if(_args[i] == "-s" || _args[i] == "--settings")
+                        {
+                            ArgData.Settings = "show";
+                            _argData.AddToLogString($"\"Settings\" requested");
+                            _argData.NoCommands = true;
+                        }
+
+                        if(_args.Count > i + 1)
+                        {
+                            SavePropertyParam(_validParamOptions[_args[i]], _args[i + 1]);
+                            _argData.AddToLogString($"Option: \"{_args[i]}\", Value: \"{_args[i + 1]}\".");
+                            i++;
+                        }
+                        else 
+                        {
+                            if(_args[i] != "-s" && _args[i] != "--settings")
+                            {
+                                _argData.AddToLogString($"\"{_args[i]}\" requires an additional argument.", true);
+                            }
+                        }
                     }
                     else
                     {
@@ -219,7 +235,9 @@ namespace Hypertherm.CcCli
             ["-u"] = "Units",
             ["--units"] = "Units",
             ["-t"] = "CcType",
-            ["--type"] = "CcType"
+            ["--type"] = "CcType",
+            ["-s"] = "Settings",
+            ["--settings"] = "Settings"
         };
         public Dictionary<string, string> ValidParamOptions => _validParamOptions;
 
@@ -232,7 +250,11 @@ namespace Hypertherm.CcCli
 
             ### When used, will not execute API commands ###
                  [-h | --help] [-v | --version] [-u | --update]
-                 [-d | --dumplog] [-c | --clearlog]
+                 [-s | --settings] [-d | --dumplog] [-c | --clearlog]
+
+                    ** Settings options **
+                         show
+                         modify <setting> <value>
 
             ### Can be used with API Commands ###
                  [-p | --product]
@@ -248,6 +270,7 @@ namespace Hypertherm.CcCli
             public string HelpString => _helpString;
             public bool Version { get; set; }
             public bool Update { get; set; }
+            public string Settings { get; set; }
             public bool DumpLog { get; set; }
             public bool ClearLog { get; set; }
             public bool Logout { get; set; }
@@ -280,6 +303,11 @@ namespace Hypertherm.CcCli
                 {
                     Debug = false,
                     Help = false,
+                    Version = false,
+                    Update = false,
+                    Settings = "",
+                    DumpLog = false,
+                    ClearLog = false,
                     Logout = false,
                     Product = "",
                     Units = "English",

--- a/cc-cli/ArgumentHandler.cs
+++ b/cc-cli/ArgumentHandler.cs
@@ -169,7 +169,7 @@ namespace Hypertherm.CcCli
                     {
                         if (!_argData.IsError)
                         {
-                            _argData.AddToLogString($"\"{_args[i]}\" is and unknown command/option(s)", true);
+                            _argData.AddToLogString($"\"{_args[i]}\" is an unknown command/option(s)", true);
                         }
                     }
                 }

--- a/cc-cli/Program.cs
+++ b/cc-cli/Program.cs
@@ -83,6 +83,8 @@ namespace Hypertherm.CcCli
             // You can build your own if you extend the IAnalyticsService interface.
             _analyzer = new ApplicationInsightsAnalytics(config, _logger);
             _analyzer.GenericTrace("Analytics Initialized.");
+            
+            _updater = new UpdateWithGitHubAPI(_analyzer, _logger);
 
             if(argHandler.ArgData.NoCommands)
             {
@@ -118,7 +120,6 @@ namespace Hypertherm.CcCli
                 else if(argHandler.ArgData.Update)
                 {
                     List<string> releases = new List<string>();
-                    _updater = new UpdateWithGitHubAPI(_analyzer, _logger);
                     releases = _updater.ListReleases()
                                        .GetAwaiter()
                                        .GetResult();
@@ -147,7 +148,7 @@ namespace Hypertherm.CcCli
 
                         if(!string.IsNullOrEmpty(userResponse) && userResponse != "none")
                         {
-                            if(userResponse == "latest" && _updater.IsUpdateAvailable().Result)
+                            if(userResponse == "latest" && _updater.IsUpdateAvailable())
                             {
                                 UpdateIsAvailableConversation();
                             }
@@ -195,10 +196,9 @@ namespace Hypertherm.CcCli
             else
             {
                 // Check for updates if enabled
-                _updater = new UpdateWithGitHubAPI(_analyzer, _logger);
                 if(_checkForUpdates)
                 {
-                    if(_updater.IsUpdateAvailable().Result)
+                    if(_updater.IsUpdateAvailable())
                     {
                         if(UpdateIsAvailableConversation())
                         {
@@ -331,7 +331,7 @@ namespace Hypertherm.CcCli
         {
             var updated = false;
 
-            _logger.Log("An update is available. Continue with update? ('y/yes' or 'n/no')", MessageType.DisplayInfo);
+            _logger.Log($"An update to cc-cli v{_updater.LatestReleasedVersion().ToString()} is available. Continue with update? ('y/yes' or 'n/no')", MessageType.DisplayInfo);
 
             if(UserYesNoRespose(testResponse))
             {

--- a/cc-cli/Program.cs
+++ b/cc-cli/Program.cs
@@ -103,7 +103,6 @@ namespace Hypertherm.CcCli
                         var settingToToggle = storageKeyBase + argHandler.ArgData.Settings;
                         if(_localStorageGlobalSettings.Exists(settingToToggle))
                         {
-                            // TODO: add validation that the given value works with the given setting
                             _localStorageGlobalSettings.Store(settingToToggle, !(bool)_localStorageGlobalSettings.Get(settingToToggle));
                             _localStorageGlobalSettings.Persist();
                         }
@@ -115,7 +114,7 @@ namespace Hypertherm.CcCli
 
                     // Possibly make a list of settings to iterate over or a standalone class to manage them
                     _logger.Log($"{storageKeyBase}settings" , MessageType.DisplayInfo);
-                    _logger.Log($"{CHECKFORUPDATES}: {_localStorageGlobalSettings.Get(storageKeyBase + CHECKFORUPDATES)}", MessageType.DisplayInfo);
+                    _logger.Log($"  {CHECKFORUPDATES}: {_localStorageGlobalSettings.Get(storageKeyBase + CHECKFORUPDATES)}", MessageType.DisplayInfo);
                 }
                 else if(argHandler.ArgData.Update)
                 {
@@ -128,25 +127,30 @@ namespace Hypertherm.CcCli
                     if(releases.Count > 0)
                     {
                         _logger.Log("Available versions:", MessageType.DisplayInfo);
-                        _logger.Log(" latest", MessageType.DisplayInfo);
                         foreach(var release in releases)
                         {
-                            _logger.Log($" {release}", MessageType.DisplayInfo);
+                            if("v" + _updater.LatestReleasedVersion().ToString() == release)
+                            {
+                                _logger.Log($"  {release} *latest*", MessageType.DisplayInfo);
+                            }
+                            else
+                            {
+                                _logger.Log($"  {release}", MessageType.DisplayInfo);
+                            }
                         }
-                        _logger.Log(" none\n", MessageType.DisplayInfo);
                         _logger.Log("Specify a version or just press 'Enter' to cancel.", MessageType.DisplayInfo);
 
                         if(Debugger.IsAttached)
                         {
                             // Change this to a version to debug the check for specifiv updates code.
-                            userResponse = "none";
+                            userResponse = "";
                         }
                         else
                         {
                             userResponse = Console.ReadLine();
                         }
 
-                        if(!string.IsNullOrEmpty(userResponse) && userResponse != "none")
+                        if(!string.IsNullOrEmpty(userResponse))
                         {
                             if(userResponse == "latest" && _updater.IsUpdateAvailable())
                             {

--- a/cc-cli/Program.cs
+++ b/cc-cli/Program.cs
@@ -118,7 +118,10 @@ namespace Hypertherm.CcCli
                 else if(argHandler.ArgData.Update)
                 {
                     List<string> releases = new List<string>();
-                    releases = _updater.ListReleases().GetAwaiter().GetResult();
+                    _updater = new UpdateWithGitHubAPI(_analyzer, _logger);
+                    releases = _updater.ListReleases()
+                                       .GetAwaiter()
+                                       .GetResult();
 
                     var userResponse = "";
                     if(releases.Count > 0)


### PR DESCRIPTION
When performing a command action the CLI will check for updates.
If a newer version exists then the user will be prompted to update.
If they choose not to, they will then be prompted with an option to disable this feature.
There is now a "check-for-updates" Global Setting that persists and can be toggled.